### PR TITLE
Disable overscroll

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -63,7 +63,6 @@ const ogImage = og.pathname + og.search;
 </html>
 
 <style>
-  html,
   body {
     margin: 0;
     width: 100%;
@@ -71,6 +70,7 @@ const ogImage = og.pathname + og.search;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='2' height='2' viewBox='0 0 2 2'%3E%3Crect width='1' height='1' fill='%23666'/%3E%3Crect x='1' y='1' width='1' height='1' fill='%23666'/%3E%3C/svg%3E");
     background-size: 4px 4px;
     background-attachment: fixed;
+    overscroll-behavior: none;
   }
 
   .toasters {


### PR DESCRIPTION
Prevents overscroll, to ensure the background stays fixed. This is to prevent the visual artifacts seen in #3

Fixes #3